### PR TITLE
Add -lntdll to Makevars.win to prevent failures with Rust 1.70

### DIFF
--- a/caviarpd/src/Makevars.win
+++ b/caviarpd/src/Makevars.win
@@ -1,2 +1,2 @@
-PKG_LIBS = -L. -lrust -lws2_32 -ladvapi32 -luserenv -lbcrypt
+PKG_LIBS = -L. -lrust -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 $(SHLIB): librust.a


### PR DESCRIPTION
For the details, please refer to https://yutani.rbind.io/post/rust-1.70-and-build-failure-on-windows/